### PR TITLE
Fix pgsql dialect string

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Update your personal preferences in Claude Desktop settings to request that gene
    - Validates SQL query syntax and returns any errors
    - Input:
      - sql (string): SQL query to analyze
-     - dialect (string, optional): SQL dialect (e.g., 'mysql', 'postgresql')
+     - dialect (string, optional): SQL dialect (e.g., 'mysql', 'postgres')
    - Returns: ParseResult containing:
      - is_valid (boolean): Whether the SQL is valid
      - message (string): Error message or "No syntax errors"

--- a/src/mcp_server_sql_analyzer/server.py
+++ b/src/mcp_server_sql_analyzer/server.py
@@ -93,7 +93,7 @@ def lint_sql(sql: str, dialect: str = "") -> ParseResult:
 
     Args:
         sql: SQL query to analyze
-        dialect: Optional SQL dialect (e.g., 'mysql', 'postgresql')
+        dialect: Optional SQL dialect (e.g., 'mysql', 'postgres')
 
     Returns:
         error message or "No syntax errors" if parsing succeeds
@@ -160,7 +160,7 @@ def get_all_table_references(
 
     Args:
         sql: SQL statement to analyze
-        dialect: Optional SQL dialect (e.g., 'mysql', 'postgresql')
+        dialect: Optional SQL dialect (e.g., 'mysql', 'postgres')
     Returns:
         JSON object containing tables with catalog, database, and alias attributes
         CTEs are returned as "cte" type
@@ -217,7 +217,7 @@ def get_all_column_references(
 
     Args:
         sql: SQL statement to analyze
-        dialect: Optional SQL dialect (e.g., 'mysql', 'postgresql')
+        dialect: Optional SQL dialect (e.g., 'mysql', 'postgres')
     Returns:
         JSON object containing column references with table context and any errors
     """


### PR DESCRIPTION
[Test code](https://github.com/j4c0bs/mcp-server-sql-analyzer/blob/8a1b62f1cb0d5e15d9b72cb714e4708d75d858e3/tests/test_lint.py#L29) correctly uses `postgres` as dialect value, but examples/comments use `postgresql` @j4c0bs 